### PR TITLE
Supabase ping script

### DIFF
--- a/.github/workflows/keep-supabase-awake.yml
+++ b/.github/workflows/keep-supabase-awake.yml
@@ -1,0 +1,31 @@
+name: Keep Supabase Awake
+
+on:
+  schedule:
+    # Every day at 07:00 UTC
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  ping-database:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Ping Supabase REST endpoint
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_ANON_KEY" ]; then
+            echo "Missing required secrets: SUPABASE_URL and/or SUPABASE_ANON_KEY"
+            exit 1
+          fi
+
+          curl -sS -f "$SUPABASE_URL/rest/v1/" \
+            -H "apikey: $SUPABASE_ANON_KEY" \
+            -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
+            -H "Accept: application/json" \
+            -o /dev/null
+
+          echo "Supabase ping succeeded"


### PR DESCRIPTION
# Keep Supabase Alive

Script that pings our Supabase database once per day 07:00 so it doesn't go idle


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated database health monitoring designed to run daily, ensuring consistent service availability and optimal responsiveness. This proactive approach prevents performance degradation that commonly occurs during extended periods of inactivity. The monitoring executes automatically on a regular schedule and can also be manually triggered whenever needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->